### PR TITLE
remove static binary options from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ permissions:
   contents: write
   packages: write
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -40,3 +44,11 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,13 +8,10 @@ builds:
   - id: castkeeper
     binary: castkeeper
     main: ./cmd/main.go
-    # env: [CGO_ENABLED=0] # SQLite requires CGO
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
-      - arm64
     ldflags:
       - -X github.com/webbgeorge/castkeeper.Version={{.Version}}
     tags:
@@ -39,3 +36,9 @@ dockers:
     extra_files:
       - castkeeper.yml.example
       - LICENSE
+release:
+  skip_upload: true
+  header: |
+    ## CastKeeper {{ .Version }}
+
+    Container image at ghcr.io/webbgeorge/castkeeper:{{ .Version }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CastKeeper
 
 CastKeeper is a free application for archiving podcasts. It is designed to be
-easy to self-host, using either Docker or a self-contained executable. It
-supports a variety of file storage options.
+easy to self-host, published as a Docker container. It supports a variety of
+file storage options.
 
 CastKeeper was built primarily to do 2 things:
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The CastKeeper server can be installed in multiple ways:
 
 - [Docker image](#docker-image)
-- [Binary](#binary)
+- [Build from source](#build-from-source)
 
 ## Docker image
 
@@ -64,11 +64,12 @@ ObjectStorage:
 
 Coming soon
 
-## Binary
+## Build From Source
 
-Note that CastKeeper binaries currently only run on Linux and MacOS.
+Note that CastKeeper currently can only be built from source on Linux and
+MacOS.
 
-1. Obtain the binary from [releases on GitHub](https://github.com/webbgeorge/castkeeper/releases)
+1. Follow the developer instructions in the [README](https://github.com/webbgeorge/castkeeper).
 2. Place the CastKeeper binary in a location in your system's `$PATH`.
 3. Install CastKeeper as a system service, e.g. using `systemctl`.
 4. [Configure CastKeeper](/getting-started/configuration).

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -12,7 +12,7 @@ versioning and release notes are used to inform uses about breaking changes.
 1. Read the release notes of the CastKeeper version you plan to update to,
    taking note of any breaking changes or specific upgrade instructions.
 1. Backup CastKeeper database and object storage data.
-1. Download the desired release of CastKeeper (e.g. docker image or binary).
+1. Download the desired release of CastKeeper (e.g. docker image).
 1. Stop the CastKeeper server and restart it with the new release.
    - Note that database updates are automatically applied by the application
      when it starts.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -6,8 +6,8 @@ slug: /
 # CastKeeper
 
 CastKeeper is a free application for archiving podcasts. It is designed to be
-easy to self-host, using either Docker or a self-contained executable. It
-supports a variety of file storage options.
+easy to self-host, published as a Docker container. It supports a variety of
+file storage options.
 
 CastKeeper was built primarily to do 2 things:
 


### PR DESCRIPTION
- Binaries aren't static due to dependency on CGO/SQLite.
- There are future plans to introduce additional dependencies which can't be embedded in the Go binary either.
