### PR TITLE
show dash instead of 0s when unable to detect episode length

### DIFF
--- a/pkg/components/partials/episode_list_item.templ
+++ b/pkg/components/partials/episode_list_item.templ
@@ -13,7 +13,13 @@ templ EpisodeListItem(csrfToken string, ep podcasts.Episode) {
 		<td>
 			@badge(ep.Status)
 		</td>
-		<td>{ fmt.Sprintf("%s", time.Duration(ep.DurationSecs) * time.Second) }</td>
+		<td>
+			if ep.DurationSecs == 0 {
+				<span>-</span>
+			} else {
+				{ fmt.Sprintf("%s", time.Duration(ep.DurationSecs) * time.Second) }
+			}
+		</td>
 		<td>
 			if ep.Status == podcasts.EpisodeStatusSuccess {
 				<a


### PR DESCRIPTION
show dash instead of 0s when unable to detect episode length