### PR TITLE
implement new user management CLI commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ run_alt_config:
 	AWS_ENDPOINT_URL=http://localhost:4566 AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=000000 AWS_SECRET_ACCESS_KEY=000000 go run -ldflags="$(FLAGS)" cmd/main.go serve --config ./castkeeper.alt.yml
 
 create_user:
-	go run cmd/main.go user create
+	go run cmd/main.go users create --username $(USERNAME) --access-level 3
 
 create_user_alt_config:
-	go run cmd/main.go user create --config ./castkeeper.alt.yml
+	go run cmd/main.go users create --config ./castkeeper.alt.yml --username $(USERNAME) --access-level 3

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ storage:
 
 ```shell
 # Create a user to log in with (first time only)
-make create_user
+make create_user USERNAME=testuser
 
 # Run server
 make run
@@ -83,7 +83,7 @@ To run locally with the alt configuration, using S3 (localstack):
 docker compose up -d
 
 # Create a user to log in with (first time only)
-make create_user_alt_config
+make create_user_alt_config USERNAME=testuser
 
 # Run server
 make run_alt_config

--- a/cmd/changepassword/changepassword.go
+++ b/cmd/changepassword/changepassword.go
@@ -1,0 +1,71 @@
+package changepassword
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/webbgeorge/castkeeper/pkg/auth/users"
+	"github.com/webbgeorge/castkeeper/pkg/config/cli"
+	"golang.org/x/term"
+)
+
+var ChangePasswordCmd = &cobra.Command{
+	Use:   "change-password",
+	Short: "Change the password of a user",
+	Long:  "Utility script for changing user passwords in the database for the given CastKeeper configuration.",
+	Run:   run,
+}
+
+var (
+	username    string
+	newPassword string
+)
+
+func init() {
+	cli.InitGlobalFlags(ChangePasswordCmd)
+	ChangePasswordCmd.Flags().StringVar(&username, "username", "", "username to change the password for")
+	ChangePasswordCmd.Flags().StringVar(&newPassword, "new-password", "", "the new password to set for the user (otherwise entered interactively)")
+	if err := ChangePasswordCmd.MarkFlagRequired("username"); err != nil {
+		panic(err)
+	}
+}
+
+func run(cmd *cobra.Command, args []string) {
+	ctx, _, db, err := cli.ConfigureCLI()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	user, err := users.GetUserByUsername(ctx, db, username)
+	if err != nil {
+		log.Fatalf("failed to get user by username: %v", err)
+	}
+
+	password, err := readPassword()
+	if err != nil {
+		log.Fatalf("failed to read password: %v", err)
+	}
+
+	err = users.UpdatePassword(ctx, db, user.ID, password)
+	if err != nil {
+		log.Fatalf("failed to change password: %v", err)
+	}
+
+	log.Printf("successfully changed password for user '%s'", username)
+}
+
+func readPassword() (string, error) {
+	argPassword := newPassword
+	if argPassword != "" {
+		return argPassword, nil
+	}
+
+	fmt.Print("Enter password: ")
+	pwBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", err
+	}
+	return string(pwBytes), nil
+}

--- a/cmd/deleteuser/deleteuser.go
+++ b/cmd/deleteuser/deleteuser.go
@@ -1,0 +1,45 @@
+package deleteuser
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/webbgeorge/castkeeper/pkg/auth/users"
+	"github.com/webbgeorge/castkeeper/pkg/config/cli"
+)
+
+var DeleteUserCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a CastKeeper user",
+	Long:  "Utility script for deleting users from the database for the given CastKeeper configuration.",
+	Run:   run,
+}
+
+var username string
+
+func init() {
+	cli.InitGlobalFlags(DeleteUserCmd)
+	DeleteUserCmd.Flags().StringVar(&username, "username", "", "username for the user to delete")
+	if err := DeleteUserCmd.MarkFlagRequired("username"); err != nil {
+		panic(err)
+	}
+}
+
+func run(cmd *cobra.Command, args []string) {
+	ctx, _, db, err := cli.ConfigureCLI()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	user, err := users.GetUserByUsername(ctx, db, username)
+	if err != nil {
+		log.Fatalf("failed to get user by username: %v", err)
+	}
+
+	err = users.DeleteUser(ctx, db, user.ID)
+	if err != nil {
+		log.Fatalf("failed to delete user: %v", err)
+	}
+
+	log.Printf("successfully deleted user '%s'", username)
+}

--- a/cmd/edituser/edituser.go
+++ b/cmd/edituser/edituser.go
@@ -1,0 +1,66 @@
+package edituser
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/webbgeorge/castkeeper/pkg/auth/users"
+	"github.com/webbgeorge/castkeeper/pkg/config/cli"
+)
+
+var EditUserCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Edit a user",
+	Long:  "Utility script for editing users in the database for the given CastKeeper configuration.",
+	Run:   run,
+}
+
+var (
+	username       string
+	newUsername    string
+	newAccessLevel int
+)
+
+func init() {
+	cli.InitGlobalFlags(EditUserCmd)
+
+	hints := make([]string, 0)
+	for _, al := range users.AccessLevels {
+		hints = append(hints, fmt.Sprintf("%d = %s", al, al.Format()))
+	}
+	accessLevelUsage := fmt.Sprintf("the new access level to set for the user (%s)", strings.Join(hints, ", "))
+
+	EditUserCmd.Flags().StringVar(&username, "username", "", "username to identify the user to edit")
+	EditUserCmd.Flags().StringVar(&newUsername, "new-username", "", "the new username to set for the user")
+	EditUserCmd.Flags().IntVar(&newAccessLevel, "new-access-level", 0, accessLevelUsage)
+	if err := EditUserCmd.MarkFlagRequired("username"); err != nil {
+		panic(err)
+	}
+	if err := EditUserCmd.MarkFlagRequired("new-username"); err != nil {
+		panic(err)
+	}
+	if err := EditUserCmd.MarkFlagRequired("new-access-level"); err != nil {
+		panic(err)
+	}
+}
+
+func run(cmd *cobra.Command, args []string) {
+	ctx, _, db, err := cli.ConfigureCLI()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	user, err := users.GetUserByUsername(ctx, db, username)
+	if err != nil {
+		log.Fatalf("failed to get user by username: %v", err)
+	}
+
+	err = users.UpdateUser(ctx, db, user.ID, newUsername, users.AccessLevel(newAccessLevel))
+	if err != nil {
+		log.Fatalf("failed to update user: %v", err)
+	}
+
+	log.Printf("successfully updated user '%s'", newUsername)
+}

--- a/cmd/listusers/listusers.go
+++ b/cmd/listusers/listusers.go
@@ -1,0 +1,41 @@
+package listusers
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/webbgeorge/castkeeper/pkg/auth/users"
+	"github.com/webbgeorge/castkeeper/pkg/config/cli"
+)
+
+var ListUsersCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List CastKeeper users",
+	Long:  "Utility script for listing users from the database for the given CastKeeper configuration.",
+	Run:   run,
+}
+
+func init() {
+	cli.InitGlobalFlags(ListUsersCmd)
+}
+
+func run(cmd *cobra.Command, args []string) {
+	ctx, _, db, err := cli.ConfigureCLI()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	userList, err := users.ListUsers(ctx, db)
+	if err != nil {
+		log.Fatalf("failed to list users: %v", err)
+	}
+
+	if len(userList) == 0 {
+		fmt.Println("No users found")
+		return
+	}
+	for _, user := range userList {
+		fmt.Printf("%d\t%s (%s)\n", user.ID, user.Username, user.AccessLevel.Format())
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,14 +5,22 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/webbgeorge/castkeeper/cmd/changepassword"
 	"github.com/webbgeorge/castkeeper/cmd/createuser"
+	"github.com/webbgeorge/castkeeper/cmd/deleteuser"
+	"github.com/webbgeorge/castkeeper/cmd/edituser"
+	"github.com/webbgeorge/castkeeper/cmd/listusers"
 	"github.com/webbgeorge/castkeeper/cmd/serve"
 	"github.com/webbgeorge/castkeeper/cmd/version"
 )
 
 func main() {
-	userRootCmd := &cobra.Command{Use: "user"}
+	userRootCmd := &cobra.Command{Use: "users"}
+	userRootCmd.AddCommand(listusers.ListUsersCmd)
 	userRootCmd.AddCommand(createuser.CreateUserCmd)
+	userRootCmd.AddCommand(changepassword.ChangePasswordCmd)
+	userRootCmd.AddCommand(edituser.EditUserCmd)
+	userRootCmd.AddCommand(deleteuser.DeleteUserCmd)
 
 	rootCmd := &cobra.Command{Use: "castkeeper"}
 	rootCmd.AddCommand(
@@ -20,6 +28,9 @@ func main() {
 		userRootCmd,
 		version.VersionCmd,
 	)
+
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "enable verbose output")
+	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (otherwise uses default locations)")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -96,11 +96,11 @@ func createGoRunCmd(configProfile, cmdName string, arg ...string) (*exec.Cmd, *b
 func createTestUser(configProfile string) error {
 	cmd, logBuf := createGoRunCmd(
 		configProfile,
-		"user",
+		"users",
 		"create",
 		"--username", e2eUsername,
 		"--password", e2ePassword,
-		"--accessLevel", "3",
+		"--access-level", "3",
 	)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to create user in e2e tests '%s', cmd logs: %s", err.Error(), logBuf.String())

--- a/pkg/config/cli/cli.go
+++ b/pkg/config/cli/cli.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/webbgeorge/castkeeper/pkg/config"
+	"github.com/webbgeorge/castkeeper/pkg/database"
+	"github.com/webbgeorge/castkeeper/pkg/framework"
+	"gorm.io/gorm"
+)
+
+var (
+	cfgFile string
+	verbose bool
+)
+
+func InitGlobalFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (otherwise uses default locations)")
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
+}
+
+func ConfigureCLI() (context.Context, config.Config, *gorm.DB, error) {
+	logLevel := slog.LevelWarn
+	_ = os.Setenv("CASTKEEPER_LOGLEVEL", "warn")
+	if verbose {
+		logLevel = slog.LevelDebug
+		_ = os.Setenv("CASTKEEPER_LOGLEVEL", "debug")
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
+	ctx := framework.ContextWithLogger(context.Background(), logger)
+
+	cfg, _, err := config.LoadConfig(cfgFile)
+	if err != nil {
+		return nil, config.Config{}, nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	db, err := database.ConfigureDatabase(cfg, logger, false)
+	if err != nil {
+		return nil, config.Config{}, nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	return ctx, cfg, db, nil
+}


### PR DESCRIPTION
- Adds new commands for edit, change password, list and delete user
- Renamed user subcommand to users (BREAKING)
- Disabled interactive input for username and access level fields - this is only used for password going forwards (BREAKING)
- Refactored common configuration into CLI config pkg